### PR TITLE
Bug fixed (download progress do not refresh).

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -86,7 +86,7 @@ let downloading = false;
 chrome.downloads.onCreated.addListener(downloadItemInfo => {
     let existItem = downloadingItems.find(item => item.id === downloadItemInfo.id);
     let downloadItem = new DownloadItem(downloadItemInfo);
-    if (!existItem) {
+    if (!existItem && downloadItemInfo.state !== 'complete' && downloadItemInfo.state !== 'interrupted') {
         downloadingItems.push(downloadItem);
     }
     startPolling();

--- a/manifest.json
+++ b/manifest.json
@@ -30,7 +30,7 @@
     "storage"
   ],
   "options_page": "options.html",
-  "version": "1.11.13",
+  "version": "1.11.14",
   "homepage_url": "https://github.com/yhl452493373/DownloadManager",
   "author": "yhl452493373",
   "minimum_chrome_version": "54"


### PR DESCRIPTION
修复下载进度条不刷新。

When Chrome is started, every `DownloadItem` will fire a `DownloadCreatedEvent`, which causes that `downloadingItems` array contains items actually not downloading. The 'updateProgress' messages they send make `getElement` return a null.

Chrome启动时，每一个`DownloadItem`都产生了一个`DownloadCreatedEvent`事件，导致`downloadingItems`数组包含了非下载中的项。这些错误项发送的`updateProgress`消息导致`getElement`返回了null。